### PR TITLE
Update ComponentStore to use EntityID

### DIFF
--- a/dungeonCrawler/ECS/Components/ComponentStorage.swift
+++ b/dungeonCrawler/ECS/Components/ComponentStorage.swift
@@ -30,29 +30,29 @@ public final class ComponentStorage {
 
     public func add<T: Component>(component: T, to entity: Entity) {
         var s = store(for: T.self)
-        s.add(component, for: entity)
+        s.add(component, for: entity.id)
         setStore(s, for: T.self)
     }
 
-    public func get<T: Component>(type: T.Type, for entity: Entity) -> T? {
-        store(for: type).get(for: entity)
+    func get<T: Component>(type: T.Type, for entity: Entity) -> T? {
+        store(for: type).get(for: entity.id)
     }
     
     public func modify<T: Component>(type: T.Type, for entity: Entity, body: (inout T) -> Void) {
         var s = store(for: type)
-        s.modify(for: entity, body)
+        s.modify(for: entity.id, body)
         setStore(s, for: type)
     }
 
     public func remove<T: Component>(type: T.Type, from entity: Entity) {
         var s = store(for: type)
-        s.removeValue(for: entity)
+        s.removeValue(for: entity.id)
         setStore(s, for: type)
     }
 
     public func removeAll(from entity: Entity) {
         for key in _stores.keys {
-            _stores[key]!.removeValue(for: entity)
+            _stores[key]!.removeValue(for: entity.id)
         }
     }
 

--- a/dungeonCrawler/ECS/Components/ComponentStore.swift
+++ b/dungeonCrawler/ECS/Components/ComponentStore.swift
@@ -9,30 +9,30 @@ import Foundation
 
 /// Type-erased protocol so ComponentStorage can hold stores of any T in one dictionary.
 protocol AnyComponentStore {
-    mutating func removeValue(for entity: Entity)
+    mutating func removeValue(for entityID: EntityID)
 }
 
-/// Concrete per-type store. Holds one [Entity: T] dictionary.
+/// Concrete per-type store. Holds one [EntityID: T] dictionary.
 struct ComponentStore<T: Component>: AnyComponentStore {
 
-    private var _data: [Entity: T] = [:]
+    private var _data: [EntityID: T] = [:]
 
-    mutating func add(_ component: T, for entity: Entity) {
-        _data[entity] = component
+    mutating func add(_ component: T, for entityID: EntityID) {
+        _data[entityID] = component
     }
 
-    func get(for entity: Entity) -> T? {
-        _data[entity]
+    func get(for entityID: EntityID) -> T? {
+        _data[entityID]
     }
 
-    mutating func modify(for entity: Entity, _ body: (inout T) -> Void) {
-        guard _data[entity] != nil else { return }
-        body(&_data[entity]!)
+    mutating func modify(for entityID: EntityID, _ body: (inout T) -> Void) {
+        guard _data[entityID] != nil else { return }
+        body(&_data[entityID]!)
     }
 
-    mutating func removeValue(for entity: Entity) {
-        _data[entity] = nil
+    mutating func removeValue(for entityID: EntityID) {
+        _data[entityID] = nil
     }
 
-    var entities: [Entity] { Array(_data.keys) }
+    var entities: [Entity] { _data.keys.map { Entity(id: $0) } }
 }

--- a/dungeonCrawler/ECS/Core/World.swift
+++ b/dungeonCrawler/ECS/Core/World.swift
@@ -13,34 +13,37 @@ public final class World {
     // MARK: - Subsystems (internal ownership)
 
     public let components = ComponentStorage()
-    private var _entities: Set<Entity> = []
+    private var _entities: Set<EntityID> = []
 
     // MARK: - Entity Lifecycle
 
     @discardableResult
     public func createEntity() -> Entity {
         let entity = Entity.init()
-        _entities.insert(entity)
+        _entities.insert(entity.id)
         return entity
     }
 
     public func destroyEntity(entity: Entity) {
         components.removeAll(from: entity)
-        _entities.remove(entity)
+        _entities.remove(entity.id)
     }
     
     public func destroyAllEntities() {
-        for entity in _entities {
+        for entityID in _entities {
+            let entity = Entity(id: entityID)
             components.removeAll(from: entity)
         }
         _entities.removeAll()
     }
 
     public func isAlive(entity: Entity) -> Bool {
-        _entities.contains(entity)
+        _entities.contains(entity.id)
     }
 
-    public var allEntities: Set<Entity> { _entities }
+    public var allEntities: Set<Entity> {
+        Set(_entities.map { Entity(id: $0) })
+    }
 
     // MARK: - Component convenience pass-throughs
 

--- a/dungeonCrawlerTests/ECS/Components/ComponentStoreTests.swift
+++ b/dungeonCrawlerTests/ECS/Components/ComponentStoreTests.swift
@@ -34,16 +34,16 @@ final class ComponentStoreTests: XCTestCase {
     
     func testAddComponent() {
         let transform = TransformComponent(position: SIMD2<Float>(10, 20))
-        store.add(transform, for: entity1)
+        store.add(transform, for: entity1.id)
         
-        let retrieved = store.get(for: entity1)
+        let retrieved = store.get(for: entity1.id)
         XCTAssertNotNil(retrieved)
         XCTAssertEqual(retrieved?.position.x, 10)
         XCTAssertEqual(retrieved?.position.y, 20)
     }
     
     func testGetNonexistentComponent() {
-        let retrieved = store.get(for: entity1)
+        let retrieved = store.get(for: entity1.id)
         XCTAssertNil(retrieved)
     }
     
@@ -51,21 +51,21 @@ final class ComponentStoreTests: XCTestCase {
         let transform1 = TransformComponent(position: SIMD2<Float>(10, 20))
         let transform2 = TransformComponent(position: SIMD2<Float>(30, 40))
         
-        store.add(transform1, for: entity1)
-        store.add(transform2, for: entity2)
+        store.add(transform1, for: entity1.id)
+        store.add(transform2, for: entity2.id)
         
-        XCTAssertEqual(store.get(for: entity1)?.position.x, 10)
-        XCTAssertEqual(store.get(for: entity2)?.position.x, 30)
+        XCTAssertEqual(store.get(for: entity1.id)?.position.x, 10)
+        XCTAssertEqual(store.get(for: entity2.id)?.position.x, 30)
     }
     
     func testOverwriteComponent() {
         let transform1 = TransformComponent(position: SIMD2<Float>(10, 20))
         let transform2 = TransformComponent(position: SIMD2<Float>(30, 40))
         
-        store.add(transform1, for: entity1)
-        store.add(transform2, for: entity1)
+        store.add(transform1, for: entity1.id)
+        store.add(transform2, for: entity1.id)
         
-        let retrieved = store.get(for: entity1)
+        let retrieved = store.get(for: entity1.id)
         XCTAssertEqual(retrieved?.position.x, 30)
         XCTAssertEqual(retrieved?.position.y, 40)
     }
@@ -74,38 +74,38 @@ final class ComponentStoreTests: XCTestCase {
     
     func testModifyComponent() {
         let transform = TransformComponent(position: SIMD2<Float>(10, 20))
-        store.add(transform, for: entity1)
+        store.add(transform, for: entity1.id)
         
-        store.modify(for: entity1) { component in
+        store.modify(for: entity1.id) { component in
             component.position.x = 100
         }
         
-        let retrieved = store.get(for: entity1)
+        let retrieved = store.get(for: entity1.id)
         XCTAssertEqual(retrieved?.position.x, 100)
         XCTAssertEqual(retrieved?.position.y, 20)
     }
     
     func testModifyNonexistentComponent() {
         // Should not crash when modifying a component that doesn't exist
-        store.modify(for: entity1) { component in
+        store.modify(for: entity1.id) { component in
             component.position.x = 100
         }
         
         // Component should still not exist
-        XCTAssertNil(store.get(for: entity1))
+        XCTAssertNil(store.get(for: entity1.id))
     }
     
     func testModifyMultipleFields() {
         let transform = TransformComponent(position: SIMD2<Float>(10, 20), rotation: 0, scale: 1)
-        store.add(transform, for: entity1)
+        store.add(transform, for: entity1.id)
         
-        store.modify(for: entity1) { component in
+        store.modify(for: entity1.id) { component in
             component.position = SIMD2<Float>(100, 200)
             component.rotation = 3.14
             component.scale = 2.0
         }
         
-        let retrieved = store.get(for: entity1)
+        let retrieved = store.get(for: entity1.id)
         let r = try? XCTUnwrap(retrieved)
         XCTAssertNotNil(r)
         if let r {
@@ -120,33 +120,33 @@ final class ComponentStoreTests: XCTestCase {
     
     func testRemoveComponent() {
         let transform = TransformComponent(position: SIMD2<Float>(10, 20))
-        store.add(transform, for: entity1)
+        store.add(transform, for: entity1.id)
         
-        XCTAssertNotNil(store.get(for: entity1))
+        XCTAssertNotNil(store.get(for: entity1.id))
         
-        store.removeValue(for: entity1)
+        store.removeValue(for: entity1.id)
         
-        XCTAssertNil(store.get(for: entity1))
+        XCTAssertNil(store.get(for: entity1.id))
     }
     
     func testRemoveNonexistentComponent() {
         // Should not crash when removing a component that doesn't exist
-        store.removeValue(for: entity1)
-        XCTAssertNil(store.get(for: entity1))
+        store.removeValue(for: entity1.id)
+        XCTAssertNil(store.get(for: entity1.id))
     }
     
     func testRemoveOneOfMany() {
         let transform1 = TransformComponent(position: SIMD2<Float>(10, 20))
         let transform2 = TransformComponent(position: SIMD2<Float>(30, 40))
         
-        store.add(transform1, for: entity1)
-        store.add(transform2, for: entity2)
+        store.add(transform1, for: entity1.id)
+        store.add(transform2, for: entity2.id)
         
-        store.removeValue(for: entity1)
+        store.removeValue(for: entity1.id)
         
-        XCTAssertNil(store.get(for: entity1))
-        XCTAssertNotNil(store.get(for: entity2))
-        XCTAssertEqual(store.get(for: entity2)?.position.x, 30)
+        XCTAssertNil(store.get(for: entity1.id))
+        XCTAssertNotNil(store.get(for: entity2.id))
+        XCTAssertEqual(store.get(for: entity2.id)?.position.x, 30)
     }
     
     // MARK: - Entities
@@ -159,8 +159,8 @@ final class ComponentStoreTests: XCTestCase {
         let transform1 = TransformComponent(position: SIMD2<Float>(10, 20))
         let transform2 = TransformComponent(position: SIMD2<Float>(30, 40))
         
-        store.add(transform1, for: entity1)
-        store.add(transform2, for: entity2)
+        store.add(transform1, for: entity1.id)
+        store.add(transform2, for: entity2.id)
         
         let entities = store.entities
         XCTAssertEqual(entities.count, 2)
@@ -172,10 +172,10 @@ final class ComponentStoreTests: XCTestCase {
         let transform1 = TransformComponent(position: SIMD2<Float>(10, 20))
         let transform2 = TransformComponent(position: SIMD2<Float>(30, 40))
         
-        store.add(transform1, for: entity1)
-        store.add(transform2, for: entity2)
+        store.add(transform1, for: entity1.id)
+        store.add(transform2, for: entity2.id)
         
-        store.removeValue(for: entity1)
+        store.removeValue(for: entity1.id)
         
         let entities = store.entities
         XCTAssertEqual(entities.count, 1)


### PR DESCRIPTION
The new approach is a utilises both Entity and EntityID:

Public API (World, ComponentStorage): Uses `Entity` for ergonomics and type safety
Internal storage (ComponentStore): Uses `EntityID` for performance
Best of both worlds: Clean API + efficient storage