### PR TITLE
Move enemytype into EnemyEntityFactory and modify EnemyTagComponent

### DIFF
--- a/dungeonCrawler/ECS/Enemy/EnemyTagComponent.swift
+++ b/dungeonCrawler/ECS/Enemy/EnemyTagComponent.swift
@@ -7,35 +7,12 @@
 
 import Foundation
 
-public enum EnemyType {
-    case charger
-    case mummy
-    case ranger
-    case tower
-
-    var textureName: String {
-        switch self {
-        case .charger: return "Charger"
-        case .mummy:   return "Mummy"
-        case .ranger:  return "Ranger"
-        case .tower:   return "Tower"
-        }
-    }
-
-    var scale: Float {
-        switch self {
-        case .charger: return 1.0
-        case .mummy:   return 1.0
-        case .ranger:  return 0.75
-        case .tower:   return 1.5
-        }
-    }
-}
-
 public struct EnemyTagComponent: Component {
-    public let enemyType: EnemyType
+    public let textureName: String
+    public let scale: Float
 
-    public init(enemyType: EnemyType) {
-        self.enemyType = enemyType
+    public init(textureName: String, scale: Float) {
+        self.textureName = textureName
+        self.scale = scale
     }
 }

--- a/dungeonCrawler/ECS/Factories/EnemyEntityFactory.swift
+++ b/dungeonCrawler/ECS/Factories/EnemyEntityFactory.swift
@@ -8,6 +8,32 @@
 import Foundation
 import simd
 
+// new enemy types should go in here
+public enum EnemyType {
+    case charger
+    case mummy
+    case ranger
+    case tower
+
+    var textureName: String {
+        switch self {
+        case .charger: return "Charger"
+        case .mummy:   return "Mummy"
+        case .ranger:  return "Ranger"
+        case .tower:   return "Tower"
+        }
+    }
+
+    var scale: Float {
+        switch self {
+        case .charger: return 1.0
+        case .mummy:   return 1.0
+        case .ranger:  return 0.75
+        case .tower:   return 1.5
+        }
+    }
+}
+
 // Components attached:
 //   • TransformComponent   — position, rotation, scale
 //   • SpriteComponent      — visual representation
@@ -42,7 +68,7 @@ public struct EnemyEntityFactory: EntityFactory {
 
         world.addComponent(component: TransformComponent(position: position, rotation: 0, scale: finalScale), to: entity)
         world.addComponent(component: SpriteComponent(textureName: type.textureName), to: entity)
-        world.addComponent(component: EnemyTagComponent(enemyType: type), to: entity)
+        world.addComponent(component: EnemyTagComponent(textureName: type.textureName, scale: type.scale), to: entity)
         world.addComponent(component: VelocityComponent(), to: entity)
         world.addComponent(component: EnemyStateComponent(), to: entity)
         world.addComponent(component: CollisionBoxComponent(size: SIMD2(48 * finalScale, 48 * finalScale)), to: entity)

--- a/dungeonCrawlerTests/ECS/EntityFactoryTests.swift
+++ b/dungeonCrawlerTests/ECS/EntityFactoryTests.swift
@@ -181,11 +181,18 @@ final class EntityFactoryTests: XCTestCase {
         XCTAssertNotNil(world.getComponent(type: EnemyTagComponent.self, for: enemy))
     }
 
-    func testMakeEnemyTagMatchesType() {
+    func testMakeEnemyTagStoresCorrectTextureName() {
         let enemy = EnemyEntityFactory(at: .zero, type: .mummy).make(in: world)
         let tag = world.getComponent(type: EnemyTagComponent.self, for: enemy)
         XCTAssertNotNil(tag)
-        XCTAssertTrue(tag!.enemyType == .mummy)
+        XCTAssertEqual(tag!.textureName, EnemyType.mummy.textureName)
+    }
+
+    func testMakeEnemyTagStoresCorrectScale() {
+        let enemy = EnemyEntityFactory(at: .zero, type: .tower).make(in: world)
+        let tag = world.getComponent(type: EnemyTagComponent.self, for: enemy)
+        XCTAssertNotNil(tag)
+        XCTAssertEqual(tag!.scale, EnemyType.tower.scale, accuracy: 0.001)
     }
 
     // MARK: - makeEnemy: VelocityComponent and EnemyStateComponent

--- a/dungeonCrawlerTests/ECS/Systems/CollisionSystemTests.swift
+++ b/dungeonCrawlerTests/ECS/Systems/CollisionSystemTests.swift
@@ -39,7 +39,7 @@ final class CollisionSystemTests: XCTestCase {
         world.addComponent(component: TransformComponent(position: position, scale: 1), to: entity)
         world.addComponent(component: CollisionBoxComponent(size: size), to: entity)
         world.addComponent(component: VelocityComponent(), to: entity)
-        world.addComponent(component: EnemyTagComponent(enemyType: .charger), to: entity)
+        world.addComponent(component: EnemyTagComponent(textureName: EnemyType.charger.textureName, scale: EnemyType.charger.scale), to: entity)
         return entity
     }
  


### PR DESCRIPTION
### Tasks Completed:
- Move EnemyType enum from `EnemyTagComponent` into `EnemyEntityFactory`
- Modify `EnemyTagComponent `from holding EnemyType to holding:
  1. textureName
  2. Scale
- Updated all call sites in `EntityFactoryTests`, `CollisionSystemTests` and `EnemyEntityFactory`.

### Future implementation:
- Add Mass variable to EnemyType enum when using mass to calculate knockback